### PR TITLE
fix run No module named 'version' bug

### DIFF
--- a/src/autocoder_nano/auto_coder_nano.py
+++ b/src/autocoder_nano/auto_coder_nano.py
@@ -17,7 +17,7 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Type, Union, Tuple
 
-from version import __version__
+from autocoder_nano.version import __version__
 
 import yaml
 import tabulate

--- a/src/autocoder_nano/version.py
+++ b/src/autocoder_nano/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "moofs"
 __license__ = "Apache License 2.0"


### PR DESCRIPTION
1. 修复启动时 No module named 'version' 问题