### PR TITLE
fix:修复在命令历史搜索模式中，按下Ctrl-C导致死循环的问题

### DIFF
--- a/src/autocoder_nano/auto_coder_nano.py
+++ b/src/autocoder_nano/auto_coder_nano.py
@@ -1551,7 +1551,13 @@ def main():
 
     @kb.add("c-c")
     def _(event):
-        event.app.exit()
+        # 如果在历史搜索模式中
+        if event.app.layout.is_searching:
+            event.app.current_buffer.history_search_text = None
+            # 清除当前缓冲区
+            event.app.current_buffer.reset()
+        else:
+            event.app.exit()
 
     @kb.add("c-k")
     def _(event):


### PR DESCRIPTION
因为操作习惯有一定几率触发这个bug，导致必须要kill掉进程